### PR TITLE
Improve queries with select more power related features

### DIFF
--- a/queries/400kv+/admin2.overpassql
+++ b/queries/400kv+/admin2.overpassql
@@ -1,46 +1,45 @@
 [out:xml][timeout:300];
-  
-  // Get the complete administrative boundary relation and its members
-  relation["boundary"="administrative"]["admin_level"="2"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
-  (.admin_boundary; >;);
-  // Convert the full relation into an area, which we use for the subsequent search
-  .admin_boundary map_to_area ->.searchArea;
-  
-  // Get towers, poles, lines, cables, etc.
-  way["power"="line"]["voltage"](if:t["voltage"] >= 400000)(area.searchArea) -> .high_voltage_lines;
-  node(w.high_voltage_lines)["power"="tower"](area.searchArea) -> .towers;
-  
-  // Get substations 
-  nwr["power"="substation"](area.searchArea) -> .all_substations;
 
-(node.all_substations(around.towers:200);
-way.all_substations(around.towers:200);
- relation.all_substations(around.towers:200);
-)-> .connected_substations;
-  
-  
+// Get the complete administrative boundary relation and its members
+relation["boundary"="administrative"]["admin_level"="2"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
+(.admin_boundary; >;);
+// Convert the full relation into an area, which we use for the subsequent search
+.admin_boundary map_to_area ->.searchArea;
 
+// Power segments
+way(area.searchArea)[~"(construction:|disused:)?power$"~"line|cable"]["voltage"](if:t["voltage"] >= 400000) -> .segments;
+node(w.segments)[~"(construction:|disused:)?power$"~"tower|pole|portal|insulator|terminal"] -> .supports;
 
-node["power"="portal"](area.searchArea) -> .portals;
+// Substations 
+nwr(area.searchArea)[~"(construction:|disused:)?power$"~"substation"] -> .substations_all;
+
+(node.substations_all(around.supports:200);
+way.substations_all(around.supports:200);
+relation.substations_all(around.supports:200);
+)-> .substations;
 
 .connected_substations map_to_area -> .substation_areas;
-node.portals(area.substation_areas)->.portals_insidesub;
-  
+nw(area.substations)["power"~"tower|pole|portal|insulator|terminal"]->.substations_supports;
+nw(area.substations)[~"^(construction:|disused:)?power$"~"^switchgear|transformer$"]->.substations_switchgears;
+
+// Circuits and sections relations
+rel(bw.segments)["power"="line_section"] -> .sections;
+rel(bw.segments)["power"="circuit"] -> .circuits_simple;
+rel(br.sections)["power"="circuit"] -> .complex_circuits;
 
 
-  
-  // Union all elements – note that we also include the original admin boundary
-  (
-    .towers;
-    .high_voltage_lines;
-    .connected_substations;
-    .portals_insidesub;
-    .admin_boundary;
-  );
-  
-  // First output: all elements with metadata
-  out meta;
-  // Second recursion: fetch all members of multipolygon relations, etc.
-  >;
-  // Output the full geometry (again with meta) so JOSM receives complete data
-  out meta;
+// Union all elements – note that we also include the original admin boundary
+(
+  .segments;
+  .supports;
+  .substations;
+  .substations_supports;
+  .substations_switchgears;
+  .sections;
+  .circuits_simple;
+  .complex_circuits;
+  .admin_boundary;
+);
+(._;>;);
+
+out meta;

--- a/queries/400kv+/admin4.overpassql
+++ b/queries/400kv+/admin4.overpassql
@@ -1,46 +1,45 @@
 [out:xml][timeout:300];
-  
-  // Get the complete administrative boundary relation and its members
-  relation["boundary"="administrative"]["admin_level"="4"]["ISO3166-2"="${iso}"]->.admin_boundary;
-  (.admin_boundary; >;);
-  // Convert the full relation into an area, which we use for the subsequent search
-  .admin_boundary map_to_area ->.searchArea;
-  
-  // Get towers, poles, lines, cables, etc.
-  way["power"="line"]["voltage"](if:t["voltage"] >= 400000)(area.searchArea) -> .high_voltage_lines;
-  node(w.high_voltage_lines)["power"="tower"](area.searchArea) -> .towers;
-  
-  // Get substations 
-  nwr["power"="substation"](area.searchArea) -> .all_substations;
 
-(node.all_substations(around.towers:200);
-way.all_substations(around.towers:200);
- relation.all_substations(around.towers:200);
-)-> .connected_substations;
-  
-  
+// Get the complete administrative boundary relation and its members
+relation["boundary"="administrative"]["admin_level"="4"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
+(.admin_boundary; >;);
+// Convert the full relation into an area, which we use for the subsequent search
+.admin_boundary map_to_area ->.searchArea;
 
+// Power segments
+way(area.searchArea)[~"(construction:|disused:)?power$"~"line|cable"]["voltage"](if:t["voltage"] >= 400000) -> .segments;
+node(w.segments)[~"(construction:|disused:)?power$"~"tower|pole|portal|insulator|terminal"] -> .supports;
 
-node["power"="portal"](area.searchArea) -> .portals;
+// Substations 
+nwr(area.searchArea)[~"(construction:|disused:)?power$"~"substation"] -> .substations_all;
+
+(node.substations_all(around.supports:200);
+way.substations_all(around.supports:200);
+relation.substations_all(around.supports:200);
+)-> .substations;
 
 .connected_substations map_to_area -> .substation_areas;
-node.portals(area.substation_areas)->.portals_insidesub;
-  
+nw(area.substations)["power"~"tower|pole|portal|insulator|terminal"]->.substations_supports;
+nw(area.substations)[~"^(construction:|disused:)?power$"~"^switchgear|transformer$"]->.substations_switchgears;
+
+// Circuits and sections relations
+rel(bw.segments)["power"="line_section"] -> .sections;
+rel(bw.segments)["power"="circuit"] -> .circuits_simple;
+rel(br.sections)["power"="circuit"] -> .complex_circuits;
 
 
-  
-  // Union all elements – note that we also include the original admin boundary
-  (
-    .towers;
-    .high_voltage_lines;
-    .connected_substations;
-    .portals_insidesub;
-    .admin_boundary;
-  );
-  
-  // First output: all elements with metadata
-  out meta;
-  // Second recursion: fetch all members of multipolygon relations, etc.
-  >;
-  // Output the full geometry (again with meta) so JOSM receives complete data
-  out meta;
+// Union all elements – note that we also include the original admin boundary
+(
+  .segments;
+  .supports;
+  .substations;
+  .substations_supports;
+  .substations_switchgears;
+  .sections;
+  .circuits_simple;
+  .complex_circuits;
+  .admin_boundary;
+);
+(._;>;);
+
+out meta;

--- a/queries/Default/admin2.overpassql
+++ b/queries/Default/admin2.overpassql
@@ -1,73 +1,42 @@
 [out:xml][timeout:500];
-  
-  // Get the complete administrative boundary relation and its members
-  relation["boundary"~"administrative|disputed"]["admin_level"="2"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
-  (.admin_boundary; >;);
-  // Convert the full relation into an area, which we use for the subsequent search
-  .admin_boundary map_to_area ->.searchArea;
-  
-  // Get towers, poles, lines, cables, etc.
-  node["power"="tower"](area.searchArea) -> .towers;
-  node["power"="pole"](area.searchArea) -> .poles;
-  way["power"="line"](area.searchArea) -> .lines_connected;
-  way["power"="line"]["voltage"](if:t["voltage"] >= 90000)(area.searchArea) -> .high_voltage_lines;
-  way["power"="cable"](area.searchArea) -> .cables;
-  node.poles(w.high_voltage_lines) -> .hv_poles;
-  
-  // Get substations explicitly as nodes, ways, and relations
-  node["power"="substation"](area.searchArea) -> .substation_nodes;
-  way["power"="substation"](area.searchArea) -> .substation_ways;
-  relation["power"="substation"](area.searchArea) -> .substation_relations;
-  
-  // And similarly for power plants, generators, and transformers
-  node["power"="plant"](area.searchArea) -> .plant_nodes;
-  way["power"="plant"](area.searchArea) -> .plant_ways;
-  relation["power"="plant"](area.searchArea) -> .plant_relations;
-  
-  node["power"="generator"](area.searchArea) -> .generator_nodes;
-  way["power"="generator"](area.searchArea) -> .generator_ways;
-  relation["power"="generator"](area.searchArea) -> .generator_relations;
-  
-  node["power"="transformer"](area.searchArea) -> .transformer_nodes;
-  way["power"="transformer"](area.searchArea) -> .transformer_ways;
-  relation["power"="transformer"](area.searchArea) -> .transformer_relations;
-  
-  node["power"="portal"](area.searchArea) -> .portal_nodes;
 
-  // Get under construction infra
-  node["construction:power"](area.searchArea) -> .construction_nodes;
-  way["construction:power"](area.searchArea) -> .construction_ways;
-  relation["construction:power"](area.searchArea) -> .construction_relations;
-  
-  // Union all elements – note that we also include the original admin boundary
-  (
-    .towers;
-    .hv_poles;
-    .cables;
-    .lines_connected;
-    .high_voltage_lines;
-    .substation_nodes;
-    .substation_ways;
-    .substation_relations;
-    .plant_nodes;
-    .plant_ways;
-    .plant_relations;
-    .generator_nodes;
-    .generator_ways;
-    .generator_relations;
-    .portal_nodes;
-    .transformer_nodes;
-    .transformer_ways;
-    .transformer_relations;
-    .construction_nodes;
-    .construction_ways;
-    .construction_relations;
-    .admin_boundary;
-  );
-  
-  // First output: all elements with metadata
-  out meta;
-  // Second recursion: fetch all members of multipolygon relations, etc.
-  >;
-  // Output the full geometry (again with meta) so JOSM receives complete data
-  out meta;
+// Get the complete administrative boundary relation and its members
+relation["boundary"~"administrative|disputed"]["admin_level"="2"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
+(.admin_boundary; >;);
+// Convert the full relation into an area, which we use for the subsequent search
+.admin_boundary map_to_area ->.searchArea;
+
+// Power line segments and their supports
+node(area.searchArea)[~"^(construction:|disused:)?power$"~"^pole|tower|terminal|insulator|portal$"] -> .supports;
+way(area.searchArea)[~"^(construction:|disused:)?power$"~"portal"] -> .linear_supports;
+way(area.searchArea)[~"^(construction:|disused:)?power$"~"^line|cable$"] -> .segments;
+
+// Substation facilities
+nwr(area.searchArea)[~"^(construction:|disused:)?power$"~"substation"] -> .substations;
+nw(area.searchArea)[~"^(construction:|disused:)?power$"~"^switchgear|transformer$"] -> .switchgears;
+
+// Generation facilities
+nwr(area.searchArea)[~"^(construction:|disused:)power$"~"^plant|generator$"] -> .generation;
+
+// Circuits and sections relations
+rel(bw.segments)["power"="line_section"] -> .sections;
+rel(bw.segments)["power"="circuit"] -> .circuits_simple;
+rel(br.sections)["power"="circuit"] -> .complex_circuits;
+
+(.circuits_simple; .complex_circuits;) -> .circuits;
+
+// Dependencies gathering
+(
+  .supports;
+  .linear_supports;
+  .segments;
+  .sections;
+  .circuits;
+  .substations;
+  .switchgears;
+  .generation;
+  .admin_boundary;
+);
+(._;>;);
+
+out meta;

--- a/queries/Default/admin4.overpassql
+++ b/queries/Default/admin4.overpassql
@@ -1,73 +1,42 @@
 [out:xml][timeout:500];
-  
-  // Get the complete administrative boundary relation and its members
-  relation["boundary"="administrative"]["admin_level"~"3|4"]["ISO3166-2"="${iso}"]->.admin_boundary;
-  (.admin_boundary; >;);
-  // Convert the full relation into an area, which we use for the subsequent search
-  .admin_boundary map_to_area ->.searchArea;
-  
-  // Get towers, poles, lines, cables, etc.
-  node["power"="tower"](area.searchArea) -> .towers;
-  node["power"="pole"](area.searchArea) -> .poles;
-  way["power"="line"](area.searchArea) -> .lines_connected;
-  way["power"="line"]["voltage"](if:t["voltage"] >= 90000)(area.searchArea) -> .high_voltage_lines;
-  way["power"="cable"](area.searchArea) -> .cables;
-  node.poles(w.high_voltage_lines) -> .hv_poles;
-  
-  // Get substations explicitly as nodes, ways, and relations
-  node["power"="substation"](area.searchArea) -> .substation_nodes;
-  way["power"="substation"](area.searchArea) -> .substation_ways;
-  relation["power"="substation"](area.searchArea) -> .substation_relations;
-  
-  // And similarly for power plants, generators, and transformers
-  node["power"="plant"](area.searchArea) -> .plant_nodes;
-  way["power"="plant"](area.searchArea) -> .plant_ways;
-  relation["power"="plant"](area.searchArea) -> .plant_relations;
-  
-  node["power"="generator"](area.searchArea) -> .generator_nodes;
-  way["power"="generator"](area.searchArea) -> .generator_ways;
-  relation["power"="generator"](area.searchArea) -> .generator_relations;
-  
-  node["power"="transformer"](area.searchArea) -> .transformer_nodes;
-  way["power"="transformer"](area.searchArea) -> .transformer_ways;
-  relation["power"="transformer"](area.searchArea) -> .transformer_relations;
-  
-  node["power"="portal"](area.searchArea) -> .portal_nodes;
 
-  // Get under construction infra
-  node["construction:power"](area.searchArea) -> .construction_nodes;
-  way["construction:power"](area.searchArea) -> .construction_ways;
-  relation["construction:power"](area.searchArea) -> .construction_relations;
-  
-  // Union all elements – note that we also include the original admin boundary
-  (
-    .towers;
-    .hv_poles;
-    .cables;
-    .lines_connected;
-    .high_voltage_lines;
-    .substation_nodes;
-    .substation_ways;
-    .substation_relations;
-    .plant_nodes;
-    .plant_ways;
-    .plant_relations;
-    .generator_nodes;
-    .generator_ways;
-    .generator_relations;
-    .portal_nodes;
-    .transformer_nodes;
-    .transformer_ways;
-    .transformer_relations;
-    .construction_nodes;
-    .construction_ways;
-    .construction_relations;
-    .admin_boundary;
-  );
-  
-  // First output: all elements with metadata
-  out meta;
-  // Second recursion: fetch all members of multipolygon relations, etc.
-  >;
-  // Output the full geometry (again with meta) so JOSM receives complete data
-  out meta;
+// Get the complete administrative boundary relation and its members
+relation["boundary"~"administrative|disputed"]["admin_level"~"3|4"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
+(.admin_boundary; >;);
+// Convert the full relation into an area, which we use for the subsequent search
+.admin_boundary map_to_area ->.searchArea;
+
+// Power line segments and their supports
+node(area.searchArea)[~"(construction:|disused:)?power$"~"^pole|tower|terminal|insulator|portal$"] -> .supports;
+way(area.searchArea)[~"(construction:|disused:)?power$"~"portal"] -> .linear_supports;
+way(area.searchArea)[~"(construction:|disused:)?power$"~"^line|cable$"] -> .segments;
+
+// Substation facilities
+nwr(area.searchArea)[~"(construction:|disused:)?power$"~"substation"] -> .substations;
+nw(area.searchArea)[~"(construction:|disused:)?power$"~"^switchgear|transformer$"] -> .switchgears;
+
+// Generation facilities
+nwr(area.searchArea)[~"(construction:|disused:)power$"~"^plant|generator$"] -> .generation;
+
+// Circuits and sections relations
+rel(bw.segments)["power"="line_section"] -> .sections;
+rel(bw.segments)["power"="circuit"] -> .circuits_simple;
+rel(br.sections)["power"="circuit"] -> .complex_circuits;
+
+(.circuits_simple; .complex_circuits;) -> .circuits;
+
+// Dependencies gathering
+(
+  .supports;
+  .linear_supports;
+  .segments;
+  .sections;
+  .circuits;
+  .substations;
+  .switchgears;
+  .generation;
+  .admin_boundary;
+);
+(._;>;);
+
+out meta;

--- a/queries/Transmission + Distribution/admin2.overpassql
+++ b/queries/Transmission + Distribution/admin2.overpassql
@@ -1,76 +1,42 @@
-[out:xml][timeout:350];
+[out:xml][timeout:500];
   
   // Get the complete administrative boundary relation and its members
-  relation["boundary"="administrative"]["admin_level"="2"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
+  relation["boundary"~"administrative|disputed"]["admin_level"="2"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
   (.admin_boundary; >;);
   // Convert the full relation into an area, which we use for the subsequent search
   .admin_boundary map_to_area ->.searchArea;
-  
-  // Get towers, poles, lines, cables, etc.
-  node["power"="tower"](area.searchArea) -> .towers;
-  node["power"="pole"](area.searchArea) -> .poles;
-  way["power"="line"](area.searchArea) -> .lines_connected;
-  way["power"="cable"](area.searchArea) -> .cables;
-  node.poles(w.high_voltage_lines) -> .hv_poles;
-  // INCLUDE MINOR LINES
-  way["power"="minor_line"](area.searchArea) -> .minor_lines;
-  
-  // Get substations explicitly as nodes, ways, and relations
-  node["power"="substation"](area.searchArea) -> .substation_nodes;
-  way["power"="substation"](area.searchArea) -> .substation_ways;
-  relation["power"="substation"](area.searchArea) -> .substation_relations;
-  
-  // And similarly for power plants, generators, and transformers
-  node["power"="plant"](area.searchArea) -> .plant_nodes;
-  way["power"="plant"](area.searchArea) -> .plant_ways;
-  relation["power"="plant"](area.searchArea) -> .plant_relations;
-  
-  node["power"="generator"](area.searchArea) -> .generator_nodes;
-  way["power"="generator"](area.searchArea) -> .generator_ways;
-  relation["power"="generator"](area.searchArea) -> .generator_relations;
-  
-  node["power"="transformer"](area.searchArea) -> .transformer_nodes;
-  way["power"="transformer"](area.searchArea) -> .transformer_ways;
-  relation["power"="transformer"](area.searchArea) -> .transformer_relations;
-  
-  node["power"="portal"](area.searchArea) -> .portal_nodes;
 
-  // Get under construction infra
-  node["construction:power"](area.searchArea) -> .construction_nodes;
-  way["construction:power"](area.searchArea) -> .construction_ways;
-  relation["construction:power"](area.searchArea) -> .construction_relations;
-  
-  
-  // Union all elements – note that we also include the original admin boundary. INCLUDE POLES and MINOR_LINES
+  // Power line segments and their supports
+  node(area.searchArea)[~"^(construction:|disused:)?power$"~"^pole|tower|terminal|insulator|portal$"] -> .supports;
+  way(area.searchArea)[~"^(construction:|disused:)?power$"~"portal"] -> .linear_supports;
+  way(area.searchArea)[~"^(construction:|disused:)?power$"~"^line|cable|minor_line$"] -> .segments;
+
+  // Substation facilities
+  nwr(area.searchArea)[~"^(construction:|disused:)?power$"~"substation"] -> .substations;
+  nw(area.searchArea)[~"^(construction:|disused:)?power$"~"^switchgear|transformer$"] -> .switchgears;
+
+  // Generation facilities
+  nwr(area.searchArea)[~"^(construction:|disused:)power$"~"^plant|generator$"] -> .generation;
+
+  // Circuits and sections relations
+  rel(bw.segments)["power"="line_section"] -> .sections;
+  rel(bw.segments)["power"="circuit"] -> .circuits_simple;
+  rel(br.sections)["power"="circuit"] -> .complex_circuits;
+
+  (.circuits_simple; .complex_circuits;) -> .circuits;
+
+  // Dependencies gathering
   (
-    .towers;
-    .hv_poles;
-    .cables;
-    .poles;
-    .lines_connected;
-    .minor_lines;
-    .substation_nodes;
-    .substation_ways;
-    .substation_relations;
-    .plant_nodes;
-    .plant_ways;
-    .plant_relations;
-    .generator_nodes;
-    .generator_ways;
-    .generator_relations;
-    .portal_nodes;
-    .transformer_nodes;
-    .transformer_ways;
-    .transformer_relations;
-    .construction_nodes;
-    .construction_ways;
-    .construction_relations;
+    .supports;
+    .linear_supports;
+    .segments;
+    .sections;
+    .circuits;
+    .substations;
+    .switchgears;
+    .generation;
     .admin_boundary;
   );
-  
-  // First output: all elements with metadata
-  out meta;
-  // Second recursion: fetch all members of multipolygon relations, etc.
-  >;
-  // Output the full geometry (again with meta) so JOSM receives complete data
+  (._;>;);
+
   out meta;

--- a/queries/Transmission + Distribution/admin4.overpassql
+++ b/queries/Transmission + Distribution/admin4.overpassql
@@ -1,75 +1,42 @@
-[out:xml][timeout:300];
+[out:xml][timeout:500];
   
   // Get the complete administrative boundary relation and its members
-  relation["boundary"="administrative"]["admin_level"="4"]["ISO3166-2"="${iso}"]->.admin_boundary;
+  relation["boundary"~"administrative|disputed"]["admin_level"~"3|4"]["ISO3166-1:alpha2"="${iso}"]->.admin_boundary;
   (.admin_boundary; >;);
   // Convert the full relation into an area, which we use for the subsequent search
   .admin_boundary map_to_area ->.searchArea;
-  
-  // Get towers, poles, lines, cables, etc.
-  node["power"="tower"](area.searchArea) -> .towers;
-  node["power"="pole"](area.searchArea) -> .poles;
-  way["power"="line"](area.searchArea) -> .lines_connected;
-  way["power"="cable"](area.searchArea) -> .cables;
-  node.poles(w.high_voltage_lines) -> .hv_poles;
-  // INCLUDE MINOR LINES
-  way["power"="minor_line"](area.searchArea) -> .minor_lines;
-  
-  // Get substations explicitly as nodes, ways, and relations
-  node["power"="substation"](area.searchArea) -> .substation_nodes;
-  way["power"="substation"](area.searchArea) -> .substation_ways;
-  relation["power"="substation"](area.searchArea) -> .substation_relations;
-  
-  // And similarly for power plants, generators, and transformers
-  node["power"="plant"](area.searchArea) -> .plant_nodes;
-  way["power"="plant"](area.searchArea) -> .plant_ways;
-  relation["power"="plant"](area.searchArea) -> .plant_relations;
-  
-  node["power"="generator"](area.searchArea) -> .generator_nodes;
-  way["power"="generator"](area.searchArea) -> .generator_ways;
-  relation["power"="generator"](area.searchArea) -> .generator_relations;
-  
-  node["power"="transformer"](area.searchArea) -> .transformer_nodes;
-  way["power"="transformer"](area.searchArea) -> .transformer_ways;
-  relation["power"="transformer"](area.searchArea) -> .transformer_relations;
-  
-  node["power"="portal"](area.searchArea) -> .portal_nodes;
 
-  // Get under construction infra
-  node["construction:power"](area.searchArea) -> .construction_nodes;
-  way["construction:power"](area.searchArea) -> .construction_ways;
-  relation["construction:power"](area.searchArea) -> .construction_relations;
-  
-  // Union all elements – note that we also include the original admin boundary. INCLUDE POLES and MINOR_LINES
+  // Power line segments and their supports
+  node(area.searchArea)[~"(construction:|disused:)?power$"~"^pole|tower|terminal|insulator|portal$"] -> .supports;
+  way(area.searchArea)[~"(construction:|disused:)?power$"~"portal"] -> .linear_supports;
+  way(area.searchArea)[~"(construction:|disused:)?power$"~"^line|cable|minor_line$"] -> .segments;
+
+  // Substation facilities
+  nwr(area.searchArea)[~"(construction:|disused:)?power$"~"substation"] -> .substations;
+  nw(area.searchArea)[~"(construction:|disused:)?power$"~"^switchgear|transformer$"] -> .switchgears;
+
+  // Generation facilities
+  nwr(area.searchArea)[~"(construction:|disused:)power$"~"^plant|generator$"] -> .generation;
+
+  // Circuits and sections relations
+  rel(bw.segments)["power"="line_section"] -> .sections;
+  rel(bw.segments)["power"="circuit"] -> .circuits_simple;
+  rel(br.sections)["power"="circuit"] -> .complex_circuits;
+
+  (.circuits_simple; .complex_circuits;) -> .circuits;
+
+  // Dependencies gathering
   (
-    .towers;
-    .hv_poles;
-    .cables;
-    .poles;
-    .lines_connected;
-    .minor_lines;
-    .substation_nodes;
-    .substation_ways;
-    .substation_relations;
-    .plant_nodes;
-    .plant_ways;
-    .plant_relations;
-    .generator_nodes;
-    .generator_ways;
-    .generator_relations;
-    .portal_nodes;
-    .transformer_nodes;
-    .transformer_ways;
-    .transformer_relations;
-    .construction_nodes;
-    .construction_ways;
-    .construction_relations;
+    .supports;
+    .linear_supports;
+    .segments;
+    .sections;
+    .circuits;
+    .substations;
+    .switchgears;
+    .generation;
     .admin_boundary;
   );
-  
-  // First output: all elements with metadata
-  out meta;
-  // Second recursion: fetch all members of multipolygon relations, etc.
-  >;
-  // Output the full geometry (again with meta) so JOSM receives complete data
+  (._;>;);
+
   out meta;


### PR DESCRIPTION
I propose these changes for overpass queries
- More concise selectors
- Select portals as ways
- Select power circuits relations
- Include construction and disused features

Significant rewrite of 400kV, default and T+D queries

It removes 90 kV threshold completely as currently unable to select > 50 kV among a list of voltages with ;

Related to https://github.com/open-energy-transition/MapYourGrid/issues/153